### PR TITLE
Correction to chat height - #119

### DIFF
--- a/s/features/chat/components/xiome-chat/styles/chat-history.css.ts
+++ b/s/features/chat/components/xiome-chat/styles/chat-history.css.ts
@@ -4,7 +4,7 @@ export default css`
 
 .history ol,
 .history slot[name="no-messages"] {
-	height: var(--xiome-chat-history-height);
+	height: var(--xiome-chat-history-height, 20em);
 	overflow-y: auto;
 	scrollbar-color: #0004 #0002;
 	scrollbar-width: thin;

--- a/s/features/chat/components/xiome-chat/styles/chat-history.css.ts
+++ b/s/features/chat/components/xiome-chat/styles/chat-history.css.ts
@@ -4,7 +4,7 @@ export default css`
 
 .history ol,
 .history slot[name="no-messages"] {
-	height: var(--xiome-chat-history-height, 20em);
+	height: var(--xiome-chat-history-height);
 	overflow-y: auto;
 	scrollbar-color: #0004 #0002;
 	scrollbar-width: thin;

--- a/s/features/chat/components/xiome-chat/xiome-chat.css.ts
+++ b/s/features/chat/components/xiome-chat/xiome-chat.css.ts
@@ -6,7 +6,7 @@ export default css`
 :host {
 	display: block;
 	max-width: 56em;
-	--xiome-chat-history-height: var(--xiome-chat-history-height, 20em);
+	--xiome-chat-history-height: 20em;
 }
 
 .modheader {


### PR DESCRIPTION
Issue originally named as a bug with the height which i have now corrected. 
Specified that height for the property instead of it trying to read from itself, then added a fall back where the property is used to match the original value.

Noticed issue now says chat height is too tall. Currently set to 20em, would this need decreasing?
